### PR TITLE
Add support for HEIC files, and a script to run them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Exiftool Scripts for Google Photos from Google Takeout
 ## TL;DR
 To fix the metadata and clobber the originals:
+```bash
+fix-metadata.sh <takeout_dir>
+```
+
+And if you like gambling:
+```bash
+fix-metadata.sh <takeout_dir> --unsafe
+```
+
+Or if you want to run the scripts yourself:
 ```
 exiftool -@ use_json.args <takeout_dir>
 exiftool -@ jpg_to_mp4.args <takeout_dir>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ exiftool -@ use_json.args <takeout_dir>
 exiftool -@ jpg_to_mp4.args <takeout_dir>
 exiftool -@ jpg_to_png.args <takeout_dir>
 exiftool -@ png_to_jpg.args <takeout_dir>
+exiftool -@ heic_to_jpg.args <takeout_dir>
 exiftool -@ was_jpg_now_mp4.args <takeout_dir>
 exiftool -@ was_jpg_now_png.args <takeout_dir>
 exiftool -@ was_png_now_jpg.args <takeout_dir>
+exiftool -@ was_heic_now_jpg.args <takeout_dir>
 ```
 
 And if you like gambling:
@@ -60,9 +62,13 @@ Rename .jpg files that are actually PNG files to have the .png extension
 ### png_to_jpg.args
 Rename .png files that are actually JPEG files to have the .jpg extension
 
+### heic_to_jpg.args
+Rename .heic files that are actually JPEG files to have the .jpg extension
+
 ### was_jpg_now_mp4.args
 ### was_jpg_now_png.args
 ### was_png_now_jpg.args
+### was_heic_now_jpg.args
 For those files renamed above, if the date-related metadata tags don't exist and
 the JSON file exists, merge the tags.
 

--- a/fix-metadata.sh
+++ b/fix-metadata.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+test -z "$1" && echo "Usage: $0 <takeout_dir> [--unsafe]" && exit 1
+
+TAKEOUT_DIR=$1
+
+exiftool -@ use_json.args "$TAKEOUT_DIR"
+exiftool -@ jpg_to_mp4.args "$TAKEOUT_DIR"
+exiftool -@ jpg_to_png.args "$TAKEOUT_DIR"
+exiftool -@ png_to_jpg.args "$TAKEOUT_DIR"
+exiftool -@ heic_to_jpg.args "$TAKEOUT_DIR"
+exiftool -@ was_jpg_now_mp4.args "$TAKEOUT_DIR"
+exiftool -@ was_jpg_now_png.args "$TAKEOUT_DIR"
+exiftool -@ was_png_now_jpg.args "$TAKEOUT_DIR"
+exiftool -@ was_heic_now_jpg.args "$TAKEOUT_DIR"
+
+if test "$2" != "--unsafe"; then exit 0; fi
+
+exiftool -@ looks_like_a_date.args "$TAKEOUT_DIR"
+exiftool -@ burst.args "$TAKEOUT_DIR"
+exiftool -@ date_from_folder.args "$TAKEOUT_DIR"

--- a/heic_to_jpg.args
+++ b/heic_to_jpg.args
@@ -1,0 +1,21 @@
+# Rename JPEGs that were incorrectly marked with the PNG extension
+
+# Recursive
+-r
+
+# Show processed filenames
+-v0
+
+# Look for PNGs ...
+-ext
+heic
+
+# ... whose content is JPEG ...
+-if
+$Filetype eq "JPEG"
+
+# ... and rename to jpg
+-filename=%f.jpg
+
+# Clobber everything
+-overwrite_original

--- a/was_heic_now_jpg.args
+++ b/was_heic_now_jpg.args
@@ -1,0 +1,34 @@
+# Fill in from Google's JSON for those JPEGs that were originally PNGSs
+
+# Start by looking at all JPEGs
+-ext
+jpg
+
+# Recursive
+-r
+
+# Show processed filenames
+-v0
+
+# Check if the corresponding JSON exists
+-if
+(-e "${Directory}/${Filename;s/\.jpg/.heic.json/i}")
+
+# Attempt to modify media only if the info doesn't already exist
+-if
+$Filetype eq "JPEG" and not $exif:DateTimeOriginal
+
+# Attempt to read in the previous heic.json. %f is without the extension
+-tagsfromfile
+%d%f.heic.json
+
+#
+# Write out the tags. Use ConvertUnixTime to try and convert the UTC timestamp
+# to a reasonable local EXIF string.
+#
+
+# EXIF for regular JPG photos
+-AllDates<${PhotoTakenTimeTimestamp;$_=ConvertUnixTime($_,1)}
+
+# Clobber everything
+-overwrite_original


### PR DESCRIPTION
I just discovered this repo and it was massively helpful to me; thanks!

One thing I did notice is that in my export there were lots of JPEG files that were mislabelled with a .heic extension, so I copied the PNG to JPEG scripts and modified them for HEIC files.

Also I added a single bash script to run all the others, for convinience.